### PR TITLE
Set request Content-Type to application/json

### DIFF
--- a/src/rpc.js
+++ b/src/rpc.js
@@ -29,7 +29,7 @@ var makeRpcRequest = function(options) {
       path: endpoint.path,
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json-rpc',
+        'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(postData, 'utf8')
       }
     };

--- a/test/rpc.test.js
+++ b/test/rpc.test.js
@@ -87,11 +87,10 @@ describe('makeRpcRequest', function() {
   it('should send a valid json-rpc 2.0 request object', function() {
     return makeRpcRequest(requestOptions)
     .then(function() {
-      var body = requestBody;
-      expect(body.jsonrpc).to.equal('2.0');
-      expect(body.method).to.exist;
-      expect(body.params).to.exist;
-      expect(body.id).to.exist;
+      expect(requestBody.jsonrpc).to.equal('2.0');
+      expect(requestBody.method).to.exist;
+      expect(requestBody.params).to.exist;
+      expect(requestBody.id).to.exist;
     });
   });
 
@@ -99,8 +98,7 @@ describe('makeRpcRequest', function() {
   function() {
     return makeRpcRequest(requestOptions)
     .then(function() {
-      var body = requestBody;
-      expect(body.params).to.deep.equal(requestOptions.params);
+      expect(requestBody.params).to.deep.equal(requestOptions.params);
     });
   });
 
@@ -108,8 +106,7 @@ describe('makeRpcRequest', function() {
   function() {
     return makeRpcRequest(requestOptions)
     .then(function() {
-      var body = requestBody;
-      expect(body.method).to.equal(requestOptions.method);
+      expect(requestBody.method).to.equal(requestOptions.method);
     });
   });
 

--- a/test/rpc.test.js
+++ b/test/rpc.test.js
@@ -68,10 +68,10 @@ describe('makeRpcRequest', function() {
     });
   });
 
-  it('should set the Content-Type header to application/json-rpc', function() {
+  it('should set the Content-Type header to application/json', function() {
     return makeRpcRequest(requestOptions)
     .then(function() {
-      expect(request.headers['content-type']).to.equal('application/json-rpc');
+      expect(request.headers['content-type']).to.equal('application/json');
     });
   });
 
@@ -79,7 +79,7 @@ describe('makeRpcRequest', function() {
   function() {
     return makeRpcRequest(requestOptions)
     .then(function() {
-      var contentLength = Buffer.byteLength(requestBody, 'utf8');
+      var contentLength = Buffer.byteLength(JSON.stringify(requestBody), 'utf8');
       expect(request.headers['content-length']).to.equal(contentLength);
     });
   });
@@ -87,7 +87,7 @@ describe('makeRpcRequest', function() {
   it('should send a valid json-rpc 2.0 request object', function() {
     return makeRpcRequest(requestOptions)
     .then(function() {
-      var body = JSON.parse(requestBody);
+      var body = requestBody;
       expect(body.jsonrpc).to.equal('2.0');
       expect(body.method).to.exist;
       expect(body.params).to.exist;
@@ -99,7 +99,7 @@ describe('makeRpcRequest', function() {
   function() {
     return makeRpcRequest(requestOptions)
     .then(function() {
-      var body = JSON.parse(requestBody);
+      var body = requestBody;
       expect(body.params).to.deep.equal(requestOptions.params);
     });
   });
@@ -108,7 +108,7 @@ describe('makeRpcRequest', function() {
   function() {
     return makeRpcRequest(requestOptions)
     .then(function() {
-      var body = JSON.parse(requestBody);
+      var body = requestBody;
       expect(body.method).to.equal(requestOptions.method);
     });
   });


### PR DESCRIPTION
In order to be compliant with the version 2 of the API (see https://api.random.org/json-rpc/2/fundamentals).
It is still compatible with the version 1 (see https://api.random.org/json-rpc/1/introduction).