### PR TITLE
fix(types): type fix of TypeError: random_org_1.default is not a cons…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See the following high-level example for getting started:
 ```javascript
 const RandomOrg = require('random-org');
 // or
-import RandomOrg from 'random-org';
+import * as RandomOrg from 'random-org';
 
 var random = new RandomOrg({ apiKey: '12345-67890-api-key' });
 random.generateIntegers({ min: 1, max: 99, n: 2 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -273,50 +273,54 @@ interface GetResultParams {
   serialNumber: number;
 }
 
-export default class RandomOrg {
-  constructor(opts: ConstructorOptions);
+declare module 'random-org' {
+  class RandomOrg {
+    constructor(opts: ConstructorOptions);
 
-  // API Key usage
-  getUsage(): Promise<GetUsageResponse>;
+    // API Key usage
+    getUsage(): Promise<GetUsageResponse>;
 
-  // Basic methods
-  generateIntegers(params: GenerateIntegersParams): Promise<RandomOrgRPCResponse<number[]>>;
+    // Basic methods
+    generateIntegers(params: GenerateIntegersParams): Promise<RandomOrgRPCResponse<number[]>>;
 
-  generateIntegerSequences(params: GenerateIntegerSequencesParams): Promise<RandomOrgRPCResponse<number[][]>>;
+    generateIntegerSequences(params: GenerateIntegerSequencesParams): Promise<RandomOrgRPCResponse<number[][]>>;
 
-  generateDecimalFractions(params: GenerateDecimalFractionsParams): Promise<RandomOrgRPCResponse<number[]>>;
+    generateDecimalFractions(params: GenerateDecimalFractionsParams): Promise<RandomOrgRPCResponse<number[]>>;
 
-  generateGaussians(params: GenerateGaussiansParams): Promise<RandomOrgRPCResponse<number[]>>;
+    generateGaussians(params: GenerateGaussiansParams): Promise<RandomOrgRPCResponse<number[]>>;
 
-  generateStrings(params: GenerateStringsParams): Promise<RandomOrgRPCResponse<string[]>>;
+    generateStrings(params: GenerateStringsParams): Promise<RandomOrgRPCResponse<string[]>>;
 
-  generateUUIDs(params: GenerateUUIDsParams): Promise<RandomOrgRPCResponse<string[]>>;
+    generateUUIDs(params: GenerateUUIDsParams): Promise<RandomOrgRPCResponse<string[]>>;
 
-  generateBlobs(params: GenerateBlobsParams): Promise<RandomOrgRPCResponse<string[]>>;
+    generateBlobs(params: GenerateBlobsParams): Promise<RandomOrgRPCResponse<string[]>>;
 
-  // Signed methods
-  generateSignedIntegers(params: WithUserData<GenerateIntegersParams>):
-    Promise<SignedRandomOrgRPCResponse<GenerateIntegersParams, number[]>>;
+    // Signed methods
+    generateSignedIntegers(params: WithUserData<GenerateIntegersParams>):
+      Promise<SignedRandomOrgRPCResponse<GenerateIntegersParams, number[]>>;
 
-  generateSignedIntegerSequences(params: WithUserData<GenerateIntegerSequencesParams>):
-    Promise<SignedRandomOrgRPCResponse<GenerateIntegerSequencesParams, number[][]>>;
+    generateSignedIntegerSequences(params: WithUserData<GenerateIntegerSequencesParams>):
+      Promise<SignedRandomOrgRPCResponse<GenerateIntegerSequencesParams, number[][]>>;
 
-  generateSignedDecimalFractions(params: WithUserData<GenerateDecimalFractionsParams>):
-    Promise<SignedRandomOrgRPCResponse<GenerateDecimalFractionsParams, number[]>>;
+    generateSignedDecimalFractions(params: WithUserData<GenerateDecimalFractionsParams>):
+      Promise<SignedRandomOrgRPCResponse<GenerateDecimalFractionsParams, number[]>>;
 
-  generateSignedGaussians(params: WithUserData<GenerateGaussiansParams>):
-    Promise<SignedRandomOrgRPCResponse<GenerateGaussiansParams, number[]>>;
+    generateSignedGaussians(params: WithUserData<GenerateGaussiansParams>):
+      Promise<SignedRandomOrgRPCResponse<GenerateGaussiansParams, number[]>>;
 
-  generateSignedStrings(params: WithUserData<GenerateStringsParams>):
-    Promise<SignedRandomOrgRPCResponse<GenerateStringsParams, string[]>>;
+    generateSignedStrings(params: WithUserData<GenerateStringsParams>):
+      Promise<SignedRandomOrgRPCResponse<GenerateStringsParams, string[]>>;
 
-  generateSignedUUIDs(params: WithUserData<GenerateUUIDsParams>):
-    Promise<SignedRandomOrgRPCResponse<GenerateUUIDsParams, string[]>>;
+    generateSignedUUIDs(params: WithUserData<GenerateUUIDsParams>):
+      Promise<SignedRandomOrgRPCResponse<GenerateUUIDsParams, string[]>>;
 
-  generateSignedBlobs(params: WithUserData<GenerateBlobsParams>):
-    Promise<SignedRandomOrgRPCResponse<GenerateBlobsParams, string[]>>;
+    generateSignedBlobs(params: WithUserData<GenerateBlobsParams>):
+      Promise<SignedRandomOrgRPCResponse<GenerateBlobsParams, string[]>>;
 
-  verifySignature(params: VerifySignatureParams): Promise<VerifySignatureResponse>;
+    verifySignature(params: VerifySignatureParams): Promise<VerifySignatureResponse>;
 
-  getResult<Params = {}, T = unknown>(params: GetResultParams): Promise<SignedRandomOrgRPCResponse<Params, T>>;
+    getResult<Params = {}, T = unknown>(params: GetResultParams): Promise<SignedRandomOrgRPCResponse<Params, T>>;
+  }
+  
+  export = RandomOrg;
 }


### PR DESCRIPTION
In TypeScript (specifically in Nest.js) if I use the import
```import RandomOrg from 'random-org';```
as shown in the README.md, I get following error
```TypeError: random_org_1.default is not a constructor```
If I use
```import * as RandomOrg from 'random-org';```
It does work but I get following type error when creating a new instance of RandomOrg with ```new RandomOrg```:
```
error TS2351: This expression is not constructable.
  Type 'typeof import("/workspace/node_modules/random-org/index")' has no construct signatures.
```

With the edits I did both of those issues are solved, but the import is changed to  
```import * as RandomOrg from 'random-org';```
which I also adjusted in the README file
